### PR TITLE
implement day filter when searching for bars

### DIFF
--- a/app/controllers/bars_controller.rb
+++ b/app/controllers/bars_controller.rb
@@ -2,6 +2,8 @@ class BarsController < ApplicationController
 
   def index
     @bars = Bar.where(suburb: params[:location])
+    days_boolean = Special.days_boolean(params[:day])
+    @bars = Bar.where(id: Special.where(monday: days_boolean[0], tuesday: days_boolean[1], wednesday: days_boolean[2], thursday: days_boolean[3], friday: days_boolean[4], saturday: days_boolean[5], sunday: days_boolean[6]).pluck(:bar_id))
   end
 
   def show

--- a/app/models/special.rb
+++ b/app/models/special.rb
@@ -1,3 +1,25 @@
 class Special < ActiveRecord::Base
   belongs_to :bar
+
+  def self.days_boolean(input)
+    case input
+    when "Mon"
+      [true, false, false, false, false, false ,false]
+    when "Tue"
+      [false, true, false, false, false, false ,false]
+    when "Wed"
+      [false, false, true, false, false, false ,false]
+    when "Thu"
+      [false, false, false, true, false, false ,false]
+    when "Fri"
+      [false, false, false, false, true, false ,false]
+    when "Sat"
+      [false, false, false, false, false, true ,false]
+    when "Sun"
+      [false, false, false, false, false, false ,true]
+    else
+      [true, true, true, true, true, true ,true]
+    end
+  end
+  
 end


### PR DESCRIPTION
Now when searching for bars in root page, the bars index page will only lists bars filtered by selected location and days.
